### PR TITLE
Use WebWorker instead of requestAnimationFrame

### DIFF
--- a/src/core/helpers/workerHelper.ts
+++ b/src/core/helpers/workerHelper.ts
@@ -1,0 +1,24 @@
+const WORKER_SCRIPT = `
+    onmessage = function(evt) { 
+        setTimeout(() => postMessage(evt.data.id), evt.data.timeout); 
+    };`;
+
+let timeoutWorker: Worker;
+
+/**
+ * setTimeout in worker context because browser does not throttle it in background mode
+ */
+export function requestWorkerTimeout(func: () => void, timeout: number = 0) {
+    if (!timeoutWorker) {
+        timeoutWorker = new Worker(URL.createObjectURL(new Blob([WORKER_SCRIPT], {type: "application/javascript"})));
+    }
+    const id = Math.random();
+    const listener = (evt: MessageEvent) => {
+        if (evt.data === id) {
+            timeoutWorker.removeEventListener("message", listener);
+            func();
+        }
+    };
+    timeoutWorker.addEventListener("message", listener);
+    timeoutWorker.postMessage({timeout, id});
+}

--- a/src/core/hooks/useRenderingPipeline.ts
+++ b/src/core/hooks/useRenderingPipeline.ts
@@ -7,6 +7,7 @@ import { RenderingPipeline } from '../helpers/renderingPipelineHelper'
 import { SegmentationConfig } from '../helpers/segmentationHelper'
 import { SourcePlayback } from '../helpers/sourceHelper'
 import { TFLite } from './useTFLite'
+import {requestWorkerTimeout} from "../helpers/workerHelper";
 
 function useRenderingPipeline(
   sourcePlayback: SourcePlayback,
@@ -31,8 +32,6 @@ function useRenderingPipeline(
     let eventCount = 0
     let frameCount = 0
     const frameDurations: number[] = []
-
-    let renderRequestId: number
 
     const newPipeline =
       segmentationConfig.pipeline === 'webgl2'
@@ -62,7 +61,7 @@ function useRenderingPipeline(
       beginFrame()
       await newPipeline.render()
       endFrame()
-      renderRequestId = requestAnimationFrame(render)
+      requestWorkerTimeout(render)
     }
 
     function beginFrame() {
@@ -101,7 +100,6 @@ function useRenderingPipeline(
 
     return () => {
       shouldRender = false
-      cancelAnimationFrame(renderRequestId)
       newPipeline.cleanUp()
       console.log(
         'Animation stopped:',

--- a/src/pipelines/helpers/webglHelper.ts
+++ b/src/pipelines/helpers/webglHelper.ts
@@ -1,3 +1,5 @@
+import {requestWorkerTimeout} from "../../core/helpers/workerHelper";
+
 /**
  * Use it along with boyswan.glsl-literal VSCode extension
  * to get GLSL syntax highlighting.
@@ -132,11 +134,11 @@ function clientWaitAsync(gl: WebGL2RenderingContext, sync: WebGLSync) {
         return
       }
       if (res === gl.TIMEOUT_EXPIRED) {
-        requestAnimationFrame(test)
+        requestWorkerTimeout(test)
         return
       }
       resolve(res)
     }
-    requestAnimationFrame(test)
+    requestWorkerTimeout(test)
   })
 }

--- a/src/pipelines/webgl2/resizingStage.ts
+++ b/src/pipelines/webgl2/resizingStage.ts
@@ -71,14 +71,14 @@ export function buildResizingStage(
   gl.useProgram(program)
   gl.uniform1i(inputFrameLocation, 0)
 
-  function render() {
+  async function render() {
     gl.viewport(0, 0, outputWidth, outputHeight)
     gl.useProgram(program)
     gl.bindFramebuffer(gl.FRAMEBUFFER, frameBuffer)
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4)
 
     // Downloads pixels asynchronously from GPU while rendering the current frame
-    readPixelsAsync(
+    await readPixelsAsync(
       gl,
       0,
       0,

--- a/src/pipelines/webgl2/webgl2Pipeline.ts
+++ b/src/pipelines/webgl2/webgl2Pipeline.ts
@@ -153,9 +153,6 @@ export function buildWebGL2Pipeline(
         )
 
   async function render() {
-    gl.clearColor(0, 0, 0, 0)
-    gl.clear(gl.COLOR_BUFFER_BIT)
-
     gl.activeTexture(gl.TEXTURE0)
     gl.bindTexture(gl.TEXTURE_2D, inputFrameTexture)
 
@@ -172,7 +169,7 @@ export function buildWebGL2Pipeline(
 
     gl.bindVertexArray(vertexArray)
 
-    resizingStage.render()
+    await resizingStage.render()
 
     addFrameEvent()
 


### PR DESCRIPTION
Hi

This PR contains 2 fixes:

1. Use WebWorker instead of requestAnimationFrame to work in background mode closes #29  closes #25 
2. Await uploading image to GPU using WebWorker.  Otherwise we running inference on previous camera frame. If you moves fast - you can see that mask delays from camera video. Example

![image](https://user-images.githubusercontent.com/3126568/197446188-abdb4573-9b14-4d80-93f8-92eacf0dfd29.png)
